### PR TITLE
Correcting extra scales

### DIFF
--- a/ssdutils.py
+++ b/ssdutils.py
@@ -44,7 +44,7 @@ SSD_PRESETS = {
                             SSDMap(Size( 3,  3), 0.725, [2, 0.5]),
                             SSDMap(Size( 1,  1), 0.9,   [2, 0.5])
                         ],
-                        extra_scale = 107.5,
+                        extra_scale = 1.075,
                         num_anchors = 8732),
     'vgg512': SSDPreset(name = 'vgg512',
                         image_size = Size(512, 512),
@@ -57,7 +57,7 @@ SSD_PRESETS = {
                             SSDMap(Size( 2,  2), 0.75, [2, 0.5]),
                             SSDMap(Size( 1,  1), 0.9,  [2, 0.5])
                         ],
-                        extra_scale = 105,
+                        extra_scale = 1.05,
                         num_anchors = 24564)
 }
 

--- a/ssdutils.py
+++ b/ssdutils.py
@@ -105,6 +105,7 @@ def get_anchors_for_preset(preset):
     anchors = []
     for k in range(len(preset.maps)):
         fk = preset.maps[k].size[0]
+        s = preset.maps[k].scale
         for size in box_sizes[k]:
             for j in range(fk):
                 y = (j+0.5)/float(fk)

--- a/ssdutils.py
+++ b/ssdutils.py
@@ -161,8 +161,7 @@ def compute_overlap(box_arr, anchors_arr, threshold):
     best = None
     good = []
 
-    if iou[best_idx] > threshold:
-        best = Score(best_idx, iou[best_idx])
+    best = Score(best_idx, iou[best_idx])
 
     for idx in good_idxs:
         good.append(Score(idx, iou[idx]))


### PR DESCRIPTION
Please correct me if I'm wrong but the extra scale is s_prime of the k+1'th feature map. This should be the scale of the k-th feature map plus (s_max - s_min) / (# feature maps). 

If your implementation was correct, either the scales for the maps would have to be multiplied by 100 at any point (and divided by 100 again at a later point) or the extra_scale would have to be divided by 100. However, 'get_anchors_for_preset' uses both values directly without performing such a transformation.

Therefore, I think this is a bug.